### PR TITLE
Add SQL parser with internal AST

### DIFF
--- a/database/sql/__init__.py
+++ b/database/sql/__init__.py
@@ -1,5 +1,5 @@
 from .metadata import ColumnDefinition, IndexDefinition, TableSchema, CatalogManager
-from .parser import parse_create_table
+from .parser import parse_create_table, parse_sql
 
 __all__ = [
     "ColumnDefinition",
@@ -7,4 +7,5 @@ __all__ = [
     "TableSchema",
     "CatalogManager",
     "parse_create_table",
+    "parse_sql",
 ]

--- a/database/sql/ast.py
+++ b/database/sql/ast.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Union, List
+
+
+@dataclass
+class Column:
+    """Reference to a column."""
+
+    name: str
+    table: Optional[str] = None
+
+
+@dataclass
+class Literal:
+    """Literal value in a query."""
+
+    value: object
+
+
+@dataclass
+class BinOp:
+    """Binary operation (e.g. comparisons, logical ops)."""
+
+    left: "Expression"
+    op: str
+    right: "Expression"
+
+
+Expression = Union[Column, Literal, BinOp]
+
+
+@dataclass
+class SelectItem:
+    expression: Expression
+    alias: Optional[str] = None
+
+
+@dataclass
+class FromClause:
+    table: str
+    alias: Optional[str] = None
+
+
+@dataclass
+class SelectQuery:
+    select_items: List[SelectItem]
+    from_clause: FromClause
+    where_clause: Optional[Expression] = None

--- a/database/sql/parser.py
+++ b/database/sql/parser.py
@@ -30,3 +30,77 @@ def parse_create_table(sql_string: str) -> TableSchema:
         pk = "PRIMARY KEY" in rest
         columns.append(ColumnDefinition(col_name, col_type.lower(), primary_key=pk))
     return TableSchema(name=name, columns=columns)
+
+import sqlglot
+from sqlglot import expressions as exp
+
+from .ast import Column, Literal, BinOp, SelectItem, FromClause, SelectQuery, Expression
+
+
+def _map_literal(lit: exp.Literal) -> Literal:
+    value: object
+    if lit.is_string:
+        value = lit.this
+    else:
+        # try to parse as int or float
+        try:
+            value = int(lit.this)
+        except ValueError:
+            try:
+                value = float(lit.this)
+            except ValueError:
+                value = lit.this
+    return Literal(value)
+
+
+def _map_expression(node: exp.Expression) -> Expression:
+    if isinstance(node, exp.Column):
+        return Column(name=node.name, table=node.table)
+    if isinstance(node, exp.Literal):
+        return _map_literal(node)
+    if isinstance(node, (exp.And, exp.Or, exp.EQ, exp.NEQ, exp.GT, exp.GTE, exp.LT, exp.LTE)):
+        left = _map_expression(node.args['this'])
+        right = _map_expression(node.args['expression'])
+        op = node.__class__.__name__.upper()
+        return BinOp(left=left, op=op, right=right)
+    raise ValueError(f"Unsupported expression: {type(node).__name__}")
+
+
+def parse_sql(sql_string: str) -> SelectQuery:
+    """Parse a simple SELECT statement into the internal AST."""
+    try:
+        parsed = sqlglot.parse_one(sql_string)
+    except Exception as e:  # pragma: no cover - ensure any parsing error is surfaced
+        raise ValueError("Invalid SQL") from e
+
+    if not isinstance(parsed, exp.Select):
+        raise ValueError("Only SELECT statements are supported")
+
+    # SELECT items
+    select_items: list[SelectItem] = []
+    for item in parsed.expressions:
+        alias: str | None = None
+        expr = item
+        if isinstance(item, exp.Alias):
+            alias = item.alias
+            expr = item.this
+        select_items.append(SelectItem(expression=_map_expression(expr), alias=alias))
+
+    from_exp = parsed.args.get("from")
+    if not from_exp or not isinstance(from_exp.this, exp.Table):
+        raise ValueError("FROM clause required")
+
+    table_expr: exp.Table = from_exp.this
+    table_name = table_expr.name
+    alias = None
+    alias_exp = table_expr.args.get("alias")
+    if alias_exp is not None and isinstance(alias_exp.this, exp.Identifier):
+        alias = alias_exp.this.this
+
+    from_clause = FromClause(table=table_name, alias=alias)
+
+    where_clause = None
+    if parsed.args.get("where") is not None:
+        where_clause = _map_expression(parsed.args["where"].this)
+
+    return SelectQuery(select_items=select_items, from_clause=from_clause, where_clause=where_clause)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ fastapi
 uvicorn
 httpx<0.25
 msgpack
+
+sqlglot

--- a/tests/sql/test_parser.py
+++ b/tests/sql/test_parser.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from database.sql.parser import parse_sql
+from database.sql.ast import Column, Literal, BinOp, SelectQuery
+
+
+def test_parse_simple_select():
+    q = parse_sql("SELECT id FROM users")
+    assert isinstance(q, SelectQuery)
+    assert len(q.select_items) == 1
+    col = q.select_items[0].expression
+    assert isinstance(col, Column)
+    assert col.name == "id"
+    assert q.from_clause.table == "users"
+    assert q.where_clause is None
+
+
+def test_parse_where_clause():
+    q = parse_sql("SELECT id FROM users WHERE city = 'NY'")
+    assert isinstance(q.where_clause, BinOp)
+    assert q.where_clause.op == "EQ"
+    left = q.where_clause.left
+    right = q.where_clause.right
+    assert isinstance(left, Column)
+    assert left.name == "city"
+    assert isinstance(right, Literal)
+    assert right.value == "NY"
+
+
+def test_parse_multiple_predicates():
+    q = parse_sql("SELECT id FROM users WHERE city = 'NY' AND status = 1")
+    assert isinstance(q.where_clause, BinOp)
+    assert q.where_clause.op == "AND"
+    left = q.where_clause.left
+    right = q.where_clause.right
+    assert isinstance(left, BinOp) and left.op == "EQ"
+    assert isinstance(right, BinOp) and right.op == "EQ"
+
+
+def test_parse_invalid_syntax():
+    with pytest.raises(ValueError):
+        parse_sql("SELECT FROM WHERE")


### PR DESCRIPTION
## Summary
- create internal SQL AST dataclasses
- implement `parse_sql` using `sqlglot`
- expose `parse_sql` from `database.sql`
- add dependency on `sqlglot`
- test SQL parser

## Testing
- `pytest tests/sql/test_parser.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6870e295f5988331b661726a3449f908