### PR TITLE
Implement rule-based query planner

### DIFF
--- a/database/sql/__init__.py
+++ b/database/sql/__init__.py
@@ -1,6 +1,7 @@
 from .metadata import ColumnDefinition, IndexDefinition, TableSchema, CatalogManager
 from .parser import parse_create_table, parse_sql
 from .query_coordinator import QueryCoordinator
+from .planner import QueryPlanner
 
 __all__ = [
     "ColumnDefinition",
@@ -10,5 +11,6 @@ __all__ = [
     "parse_create_table",
     "parse_sql",
     "QueryCoordinator",
+    "QueryPlanner",
 ]
 

--- a/database/sql/planner.py
+++ b/database/sql/planner.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+from .ast import SelectQuery, Expression, BinOp, Column, Literal
+from .execution import SeqScanNode, IndexScanNode
+from .metadata import CatalogManager
+
+
+class QueryPlanner:
+    """Very small rule-based query planner."""
+
+    def __init__(self, db, catalog: CatalogManager, index_manager) -> None:
+        self.db = db
+        self.catalog = catalog
+        self.index_manager = index_manager
+
+    # internal helpers -------------------------------------------------
+    def _get_index_columns(self, table: str) -> set[str]:
+        schema = self.catalog.get_schema(table)
+        cols: set[str] = set()
+        if schema and schema.indexes:
+            for idx in schema.indexes:
+                cols.update(idx.columns)
+        return cols
+
+    def _find_eq_predicate(self, expr: Optional[Expression]) -> Optional[Tuple[str, Expression]]:
+        if expr is None:
+            return None
+        if isinstance(expr, BinOp):
+            if expr.op == "EQ":
+                if isinstance(expr.left, Column):
+                    return expr.left.name, expr.right
+                if isinstance(expr.right, Column):
+                    return expr.right.name, expr.left
+            left = self._find_eq_predicate(expr.left)
+            if left:
+                return left
+            return self._find_eq_predicate(expr.right)
+        return None
+
+    # public API -------------------------------------------------------
+    def create_plan(self, query: SelectQuery):
+        table = query.from_clause.table
+        indexed_columns = self._get_index_columns(table)
+        eq_pred = self._find_eq_predicate(query.where_clause)
+
+        if eq_pred and eq_pred[0] in indexed_columns:
+            column, value_expr = eq_pred
+            lookup_value = None
+            if isinstance(value_expr, Literal):
+                lookup_value = value_expr.value
+            return IndexScanNode(
+                self.db,
+                self.index_manager,
+                table,
+                column,
+                lookup_value,
+            )
+        return SeqScanNode(self.db, table, where_clause=query.where_clause)

--- a/tests/sql/test_planner.py
+++ b/tests/sql/test_planner.py
@@ -1,0 +1,83 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+dummy_rep = types.ModuleType("database.replication")
+dummy_rep.NodeCluster = object
+dummy_rep.ClusterNode = object
+dummy_rep.__path__ = []
+sub = types.ModuleType("database.replication.replica")
+sub.replication_pb2 = types.ModuleType("database.replication.replica.replication_pb2")
+sys.modules.setdefault("database.replication.replica", sub)
+sys.modules.setdefault("database.replication", dummy_rep)
+
+from database.sql.parser import parse_sql
+from database.sql.planner import QueryPlanner
+from database.sql.metadata import (
+    ColumnDefinition,
+    IndexDefinition,
+    TableSchema,
+    CatalogManager,
+)
+from database.sql.execution import SeqScanNode, IndexScanNode
+from database.lsm.lsm_db import SimpleLSMDB
+
+
+class DummyNode:
+    def __init__(self, db):
+        self.db = db
+        self.replication_log = {}
+
+    def next_op_id(self):
+        return "n1:1"
+
+    def save_replication_log(self):
+        pass
+
+    def replicate(self, *args, **kwargs):
+        pass
+
+
+def test_planner_selects_index(tmp_path):
+    db = SimpleLSMDB(db_path=tmp_path)
+    node = DummyNode(db)
+    catalog = CatalogManager(node)
+    schema = TableSchema(
+        name="users",
+        columns=[
+            ColumnDefinition("id", "int"),
+            ColumnDefinition("city", "string"),
+        ],
+        indexes=[IndexDefinition("by_city", ["city"])],
+    )
+    catalog.save_schema(schema)
+
+    planner = QueryPlanner(db, catalog, index_manager=object())
+    query = parse_sql("SELECT id FROM users WHERE city = 'NY'")
+
+    plan = planner.create_plan(query)
+    assert isinstance(plan, IndexScanNode)
+    db.close()
+
+
+def test_planner_seq_scan_when_no_index(tmp_path):
+    db = SimpleLSMDB(db_path=tmp_path)
+    node = DummyNode(db)
+    catalog = CatalogManager(node)
+    schema = TableSchema(
+        name="users",
+        columns=[
+            ColumnDefinition("id", "int"),
+            ColumnDefinition("age", "int"),
+        ]
+    )
+    catalog.save_schema(schema)
+
+    planner = QueryPlanner(db, catalog, index_manager=object())
+    query = parse_sql("SELECT id FROM users WHERE age > 30")
+
+    plan = planner.create_plan(query)
+    assert isinstance(plan, SeqScanNode)
+    db.close()


### PR DESCRIPTION
## Summary
- create `QueryPlanner` to decide between SeqScan and IndexScan
- expose `QueryPlanner` in sql package
- add unit tests ensuring planner uses indexes when possible

## Testing
- `pytest -q tests/sql/test_planner.py`
- `pytest -q` *(fails: VersionError and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68711e5e590c8331844e3c88432d2e1a