### PR TITLE
Add QueryPlanner and tests

### DIFF
--- a/database/sql/planner.py
+++ b/database/sql/planner.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from .ast import SelectQuery, BinOp, Column, Literal
+from .execution import SeqScanNode, IndexScanNode
+from .metadata import CatalogManager
+from ..clustering.index_manager import IndexManager
+from ..lsm.lsm_db import SimpleLSMDB
+
+
+class QueryPlanner:
+    """Simple rule-based query planner."""
+
+    def __init__(self, db: SimpleLSMDB, catalog: CatalogManager, index_manager: IndexManager) -> None:
+        self.db = db
+        self.catalog = catalog
+        self.index_manager = index_manager
+
+    def create_plan(self, query: SelectQuery):
+        """Return a plan node for ``query`` based on simple rules."""
+        table = query.from_clause.table
+        where = query.where_clause
+
+        indexed_cols: set[str] = set()
+        schema = self.catalog.get_schema(table)
+        if schema and schema.indexes:
+            for idx in schema.indexes:
+                indexed_cols.update(idx.columns)
+
+        if (
+            isinstance(where, BinOp)
+            and where.op == "EQ"
+            and isinstance(where.left, Column)
+            and isinstance(where.right, Literal)
+            and where.left.name in indexed_cols
+        ):
+            return IndexScanNode(
+                self.db,
+                self.index_manager,
+                table,
+                where.left.name,
+                where.right.value,
+            )
+
+        return SeqScanNode(self.db, table, where_clause=where)

--- a/tests/sql/test_planner.py
+++ b/tests/sql/test_planner.py
@@ -1,0 +1,61 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from database.sql.planner import QueryPlanner
+from database.sql.ast import Column, Literal, BinOp, SelectItem, FromClause, SelectQuery
+from database.sql.metadata import ColumnDefinition, IndexDefinition, TableSchema, CatalogManager
+from database.lsm.lsm_db import SimpleLSMDB
+from database.clustering.index_manager import IndexManager
+
+
+class DummyNode:
+    def __init__(self, db):
+        self.db = db
+
+
+def _planner_with_schema(tmp_path, indexes=None):
+    db = SimpleLSMDB(db_path=tmp_path)
+    node = DummyNode(db)
+    catalog = CatalogManager(node)
+    schema = TableSchema(
+        name="users",
+        columns=[
+            ColumnDefinition("id", "int"),
+            ColumnDefinition("age", "int"),
+            ColumnDefinition("city", "str"),
+        ],
+        indexes=indexes or [],
+    )
+    catalog.schemas["users"] = schema
+    index_manager = IndexManager([c for idx in (indexes or []) for c in idx.columns])
+    planner = QueryPlanner(db, catalog, index_manager)
+    return planner, db
+
+
+def test_plan_selects_index(tmp_path):
+    idx = IndexDefinition("by_city", ["city"])
+    planner, db = _planner_with_schema(tmp_path, [idx])
+    query = SelectQuery(
+        select_items=[SelectItem(Column("*"))],
+        from_clause=FromClause(table="users"),
+        where_clause=BinOp(left=Column("city"), op="EQ", right=Literal("NY")),
+    )
+    plan = planner.create_plan(query)
+    from database.sql.execution import IndexScanNode
+    assert isinstance(plan, IndexScanNode)
+    db.close()
+
+
+def test_plan_falls_back_to_seq_scan(tmp_path):
+    planner, db = _planner_with_schema(tmp_path)
+    query = SelectQuery(
+        select_items=[SelectItem(Column("*"))],
+        from_clause=FromClause(table="users"),
+        where_clause=BinOp(left=Column("age"), op="GT", right=Literal(30)),
+    )
+    plan = planner.create_plan(query)
+    from database.sql.execution import SeqScanNode
+    assert isinstance(plan, SeqScanNode)
+    db.close()


### PR DESCRIPTION
## Summary
- create rule-based query planner that uses indexes when possible
- test planner to ensure index scan usage

## Testing
- `pytest tests/sql/test_planner.py::test_plan_selects_index -q`
- `pytest tests/sql/test_planner.py::test_plan_falls_back_to_seq_scan -q`
- `pytest tests/sql/test_execution.py::test_merging_iterator -q`

------
https://chatgpt.com/codex/tasks/task_e_68711e5e590c8331844e3c88432d2e1a