### PR TITLE
Add ALTER TABLE ADD COLUMN support

### DIFF
--- a/database/sql/metadata.py
+++ b/database/sql/metadata.py
@@ -203,3 +203,13 @@ class CatalogManager:
         self.node.save_replication_log()
         self.node.replicate("PUT", key, value, ts, op_id=op_id, vector=vc.clock)
         self.schemas[schema.name] = schema
+
+    def add_column_to_table(self, table_name: str, column_def: ColumnDefinition) -> None:
+        """Add ``column_def`` to ``table_name`` and persist the updated schema."""
+        schema = self.schemas.get(table_name)
+        if schema is None:
+            raise KeyError("Unknown table")
+        if any(c.name == column_def.name for c in schema.columns):
+            raise ValueError("Column already exists")
+        schema.columns.append(column_def)
+        self.save_schema(schema)

--- a/database/sql/parser.py
+++ b/database/sql/parser.py
@@ -31,6 +31,29 @@ def parse_create_table(sql_string: str) -> TableSchema:
         columns.append(ColumnDefinition(col_name, col_type.lower(), primary_key=pk))
     return TableSchema(name=name, columns=columns)
 
+
+def parse_alter_table(sql_string: str) -> tuple[str, ColumnDefinition]:
+    """Parse ``ALTER TABLE ... ADD COLUMN`` statements."""
+    ddl = sql_string.strip().rstrip(";")
+    m = re.match(
+        r"ALTER\s+TABLE\s+(\w+)\s+ADD\s+COLUMN\s+(.*)$",
+        ddl,
+        re.IGNORECASE,
+    )
+    if not m:
+        raise ValueError("Invalid ALTER TABLE syntax")
+    table = m.group(1)
+    col_part = m.group(2).strip()
+    parts = col_part.split()
+    if len(parts) < 2:
+        raise ValueError("Invalid column definition")
+    col_name = parts[0]
+    col_type = parts[1]
+    rest = " ".join(parts[2:]).upper()
+    pk = "PRIMARY KEY" in rest
+    column = ColumnDefinition(col_name, col_type.lower(), primary_key=pk)
+    return table, column
+
 import sqlglot
 from sqlglot import expressions as exp
 

--- a/database/sql/planner.py
+++ b/database/sql/planner.py
@@ -71,8 +71,14 @@ class QueryPlanner:
                 table,
                 column,
                 lookup_value,
+                catalog=self.catalog,
             )
-        return SeqScanNode(self.db, table, where_clause=where_clause)
+        return SeqScanNode(
+            self.db,
+            table,
+            where_clause=where_clause,
+            catalog=self.catalog,
+        )
 
     # public API -------------------------------------------------------
     def create_plan(self, query):

--- a/tests/sql/test_ddl.py
+++ b/tests/sql/test_ddl.py
@@ -1,13 +1,16 @@
 import os
 import time
 import sys
+import json
 import grpc
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
-from database.sql.parser import parse_create_table
+from database.sql.parser import parse_create_table, parse_alter_table
 from database.sql.metadata import TableSchema, ColumnDefinition
+from database.sql.query_coordinator import QueryCoordinator
+from database.clustering.partitioning import compose_key
 from database.replication import NodeCluster
 
 
@@ -45,5 +48,60 @@ def test_duplicate_table(tmp_path):
         time.sleep(0.2)
         with pytest.raises(grpc.RpcError):
             cluster.nodes[0].client.execute_ddl(ddl)
+    finally:
+        cluster.shutdown()
+
+
+def test_parse_alter_table():
+    table, col = parse_alter_table("ALTER TABLE t ADD COLUMN age INT")
+    assert table == "t"
+    assert isinstance(col, ColumnDefinition)
+    assert col.name == "age"
+    assert col.data_type == "int"
+
+
+def test_alter_table_add_column(tmp_path):
+    cluster = NodeCluster(base_path=tmp_path, num_nodes=1)
+    try:
+        cluster.nodes[0].client.execute_ddl(
+            "CREATE TABLE users (id INT PRIMARY KEY, name STRING)"
+        )
+        time.sleep(0.5)
+        cluster.nodes[0].client.execute_ddl(
+            "ALTER TABLE users ADD COLUMN age INT"
+        )
+        time.sleep(0.5)
+        val = cluster.get(0, "_meta:table:users")
+        schema = TableSchema.from_json(val)
+        assert any(c.name == "age" for c in schema.columns)
+    finally:
+        cluster.shutdown()
+
+
+def test_alter_table_backward_compat(tmp_path):
+    cluster = NodeCluster(base_path=tmp_path, num_nodes=1)
+    try:
+        cluster.nodes[0].client.execute_ddl(
+            "CREATE TABLE users (id INT PRIMARY KEY, name STRING)"
+        )
+        time.sleep(0.5)
+        cluster.nodes[0].client.put(
+            compose_key("users", "1", None),
+            json.dumps({"id": 1, "name": "a"}),
+        )
+        time.sleep(0.2)
+        cluster.nodes[0].client.execute_ddl(
+            "ALTER TABLE users ADD COLUMN age INT"
+        )
+        time.sleep(0.5)
+        cluster.nodes[0].client.put(
+            compose_key("users", "2", None),
+            json.dumps({"id": 2, "name": "b", "age": 30}),
+        )
+        time.sleep(0.5)
+        qc = QueryCoordinator(cluster.nodes)
+        rows = sorted(qc.execute("SELECT * FROM users"), key=lambda r: r["id"])
+        assert rows[0].get("age") is None
+        assert rows[1].get("age") == 30
     finally:
         cluster.shutdown()


### PR DESCRIPTION
## Summary
- support `ALTER TABLE ... ADD COLUMN` DDL
- update catalog with `add_column_to_table`
- ensure scans fill missing fields using table schema
- update planner and gRPC server
- test new ALTER TABLE behaviour

## Testing
- `pytest -q tests/sql/test_ddl.py::test_parse_alter_table -q`
- `pytest -q tests/sql/test_ddl.py::test_alter_table_add_column tests/sql/test_ddl.py::test_alter_table_backward_compat -q`
- `pytest -q tests/sql/test_ddl.py -q`
- `pytest -q` *(interrupted after ~33% to save time)*

------
https://chatgpt.com/codex/tasks/task_e_68713d7644c08331baba6475a393f1a0