### PR TITLE
Add query plan visualization

### DIFF
--- a/app/components/QueryPlanVisualizer.tsx
+++ b/app/components/QueryPlanVisualizer.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+export interface PlanNode {
+  node_type: string;
+  blocksAccessed?: number;
+  recordsOutput?: number;
+  children?: PlanNode[];
+  [key: string]: any;
+}
+
+interface Props {
+  plan: PlanNode;
+}
+
+const renderNode = (node: PlanNode): JSX.Element => {
+  return (
+    <li>
+      <span title={`blocks: ${node.blocksAccessed ?? 0}, rows: ${node.recordsOutput ?? 0}`}>{node.node_type}</span>
+      {node.children && node.children.length > 0 && (
+        <ul className="ml-4 list-disc">
+          {node.children.map((c, idx) => (
+            <React.Fragment key={idx}>{renderNode(c)}</React.Fragment>
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+};
+
+const QueryPlanVisualizer: React.FC<Props> = ({ plan }) => {
+  return (
+    <div className="p-2">
+      <ul className="list-disc">
+        {renderNode(plan)}
+      </ul>
+    </div>
+  );
+};
+
+export default QueryPlanVisualizer;
+

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -340,6 +340,15 @@ export const runSqlQuery = async (sql: string): Promise<SqlQueryResult> => {
   return { columns: data.columns || [], rows: data.rows || [] };
 };
 
+export const explainSql = async (sql: string): Promise<any> => {
+  const data = await fetchJson<any>('/sql/explain', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ sql }),
+  });
+  return data;
+};
+
 export const executeSql = async (sql: string): Promise<void> => {
   await fetchJson('/sql/execute', {
     method: 'POST',

--- a/app/services/index.ts
+++ b/app/services/index.ts
@@ -17,5 +17,6 @@ export {
   getClusterEvents,
   getNodeEvents,
   runSqlQuery,
+  explainSql,
   executeSql,
 } from './api';

--- a/app/tests/QueryPlanVisualizer.test.tsx
+++ b/app/tests/QueryPlanVisualizer.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import QueryPlanVisualizer, { PlanNode } from '../components/QueryPlanVisualizer'
+
+const plan: PlanNode = {
+  node_type: 'NestedLoopJoin',
+  children: [
+    { node_type: 'SeqScan', table: 'a' },
+    { node_type: 'IndexScan', table: 'b', index: 'idx' },
+  ],
+}
+
+describe('QueryPlanVisualizer', () => {
+  it('renders plan tree', () => {
+    render(<QueryPlanVisualizer plan={plan} />)
+    expect(screen.getByText('NestedLoopJoin')).toBeInTheDocument()
+    expect(screen.getAllByText('SeqScan')[0]).toBeInTheDocument()
+    expect(screen.getAllByText('IndexScan')[0]).toBeInTheDocument()
+  })
+})

--- a/tests/api/test_sql_endpoints.py
+++ b/tests/api/test_sql_endpoints.py
@@ -25,3 +25,13 @@ def test_sql_query_and_execute():
         assert resp.status_code == 200
         data = resp.json()
         assert data['rows'] and data['rows'][0]['id'] == 1
+
+
+def test_sql_explain_endpoint():
+    with TestClient(app) as client:
+        resp = client.post('/sql/execute', json={'sql': 'CREATE TABLE t (id INT PRIMARY KEY)'} )
+        assert resp.status_code == 200
+        resp = client.post('/sql/explain', json={'sql': 'SELECT * FROM t'})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data['node_type'] == 'SeqScan'


### PR DESCRIPTION
## Summary
- implement `to_dict()` for plan nodes
- add planner cost estimations
- add `/sql/explain` endpoint and API function
- implement `QueryPlanVisualizer` component and tests
- test new API endpoint

## Testing
- `npm --prefix app test`
- `pytest -q` *(fails: RegistryNodeChangesTest::test_registry_reports_node_changes, ReplicationManagerTest::test_concurrent_puts_last_timestamp_wins)*

------
https://chatgpt.com/codex/tasks/task_e_68717bf882308331bd66f406d3edf768