### PR TITLE
Add host parameter to NodeCluster

### DIFF
--- a/examples/ecommerce_cluster.py
+++ b/examples/ecommerce_cluster.py
@@ -25,6 +25,7 @@ def main() -> None:
         partition_strategy="hash",
         replication_factor=2,
         partitions_per_node=32,
+        host="127.0.0.1",
     )
 
     print("Partition map:")


### PR DESCRIPTION
## Summary
- allow NodeCluster to bind on a custom host
- bind to `127.0.0.1` in ecommerce_cluster example

## Testing
- `pytest tests/test_start_node.py -q`
- `pytest tests/test_registry_node_changes.py -q`
- `pytest tests/test_registry.py -q`
- `pytest tests/test_driver_notifications.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687818391de883319ce9f205df0231b5