### PR TITLE
Improve Windows compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,9 @@ The project can be fully containerized using Docker and Docker Compose.
 
 ### Build and Run a Single Example
 To avoid compatibility issues, especially on Windows, run the project inside Docker. First, install **Docker Desktop**.
+On Windows, gRPC may log warnings when binding to `localhost`. The cluster
+now automatically converts `localhost` to `127.0.0.1`, but you can also pass
+`host="127.0.0.1"` explicitly when creating `NodeCluster`.
 ```bash
 # Build the Docker image
 docker build -t py_db .

--- a/README_pt_BR.md
+++ b/README_pt_BR.md
@@ -243,6 +243,10 @@ O projeto pode ser totalmente containerizado usando Docker e Docker Compose.
 
 ### Construir e Executar um Exemplo
 Para evitar problemas de compatibilidade, especialmente no Windows, execute o projeto dentro do Docker. Primeiro, instale o **Docker Desktop**.
+No Windows, o gRPC pode emitir avisos ao tentar vincular `localhost`. O
+cluster agora converte automaticamente `localhost` para `127.0.0.1`, mas
+você também pode definir explicitamente `host="127.0.0.1"` ao criar o
+`NodeCluster`.
 ```bash
 # Construir a imagem Docker
 docker build -t py_db .

--- a/database/replication/replica/grpc_server.py
+++ b/database/replication/replica/grpc_server.py
@@ -1060,6 +1060,12 @@ class NodeServer:
         tx_lock_strategy: str = "2pl",
         lock_timeout: float = 1.0,
     ):
+        if host == "localhost" and os.name == "nt":
+            # gRPC on Windows fails when binding to IPv4 and IPv6 for
+            # "localhost". Use the IPv4 loopback address to avoid
+            # WSA 10048 errors.
+            host = "127.0.0.1"
+
         self.db_path = db_path
         if isinstance(event_logger, str):
             event_logger = EventLogger(event_logger)

--- a/database/replication/replication.py
+++ b/database/replication/replication.py
@@ -102,6 +102,12 @@ class NodeCluster:
         self.event_logger.log("NodeCluster created")
         self.node_loggers: dict[str, EventLogger] = {}
 
+        if host == "localhost" and os.name == "nt":
+            # gRPC on Windows fails when binding to both IPv4 and IPv6
+            # addresses for "localhost". Force IPv4 loopback to avoid
+            # "WSA Error 10048" warnings.
+            host = "127.0.0.1"
+
         base_port = 9000
         self.base_port = base_port
         self.host = host


### PR DESCRIPTION
## Summary
- tweak NodeCluster and NodeServer to force IPv4 localhost on Windows
- document Windows-specific gRPC note in both READMEs

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover -s tests -v` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68781e35daf48331853317b7559ed8b8