### PR TITLE
Improve SQL error handling in UI

### DIFF
--- a/app/services/request.ts
+++ b/app/services/request.ts
@@ -2,10 +2,20 @@ export const API_BASE =
   (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_API_BASE) ||
   'http://localhost:8000';
 
-export const fetchJson = async <T>(path: string, options?: RequestInit): Promise<T> => {
+export const fetchJson = async <T>(
+  path: string,
+  options?: RequestInit,
+): Promise<T> => {
   const resp = await fetch(`${API_BASE}${path}`, options);
   if (!resp.ok) {
-    throw new Error(`Request failed: ${resp.status}`);
+    let message = `Request failed: ${resp.status}`;
+    try {
+      const data = await resp.json();
+      if (data && data.detail) message = data.detail;
+    } catch {
+      // ignore json parse errors and fall back to status message
+    }
+    throw new Error(message);
   }
   if (
     resp.status === 204 ||

--- a/app/tests/SQLEditor.test.tsx
+++ b/app/tests/SQLEditor.test.tsx
@@ -32,4 +32,13 @@ describe('SQLEditor', () => {
     expect(screen.getByText('id')).toBeInTheDocument()
     expect(screen.getAllByText('1')[0]).toBeInTheDocument()
   })
+
+  it('shows error alert on failure', async () => {
+    ;(runSqlQuery as any).mockRejectedValue(new Error('bad query'))
+    render(<SQLEditor />)
+    const input = screen.getByTestId('sql-input')
+    fireEvent.change(input, { target: { value: 'SELECT * FROM bad' } })
+    fireEvent.click(screen.getByText('Run'))
+    await screen.findByText('bad query')
+  })
 })


### PR DESCRIPTION
## Summary
- show detailed error messages from the API
- display SQL execution errors in the SQL editor
- test error handling in `SQLEditor`

## Testing
- `npm test`
- `pytest -q` *(fails: grpc channel errors)*

------
https://chatgpt.com/codex/tasks/task_e_687928b9f73c8331b794710269ac4653